### PR TITLE
Responsive layout patches

### DIFF
--- a/contact.css
+++ b/contact.css
@@ -24,8 +24,8 @@ img.vert {
   .con{
     z-index: 12;
     max-width: 1050px;
-    margin-left: 10%;
-    width: 100%;
+    margin: 10px auto;
+    width: 90%;
     background: rgb(5, 2, 51);
     border-radius: 12px;
     box-shadow: 0 5px 10px rgba(0, 0, 0, 0.15);

--- a/index.css
+++ b/index.css
@@ -149,8 +149,7 @@ a:hover{
 
 /* -------------------PROJECT---------------- */
 
-.main{
-  display: flex;
+/* .main{
   padding-left: 0px;
   padding-right: 0px;
   padding-top: 3%;
@@ -160,13 +159,23 @@ a:hover{
   position:relative;
   width: 100%;
   background-repeat: no-repeat;
+} */
+
+.flip-card-container {
+  display: grid;
+  padding: 10px;
+  align-items: center;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  grid-gap: 10px;
 }
+
   .flip-card {
     width: 300px;
     height: 300px;
     perspective: 1000px;
-    padding: 60px;
-    display:flex;
+    margin: 20px auto;
+    grid-template-columns: repeat(3, 1fr);
+    grid-template-rows: repeat(2, 300px);
     
   }
 
@@ -189,7 +198,6 @@ a:hover{
     position: absolute;
     width: 100%;
     height: 100%;
-    border:1 px solid;
     border-radius: 20%;
     -webkit-backface-visibility: hidden;
     backface-visibility: hidden;

--- a/index.html
+++ b/index.html
@@ -52,9 +52,9 @@
 
 <section id="projects">
 <h1 class="top">PROJECTS</h1>
-<div class="main">
 
 
+<div class="flip-card-container">
  <div class="flip-card">
       <div class="flip-card-inner">
         <div class="flip-card-front">
@@ -98,6 +98,7 @@
           </div>
         </div>
       </div>
+    </div>
     </section>
   </div>
 </div>

--- a/index.html
+++ b/index.html
@@ -187,12 +187,11 @@
 
 <section id="skills">
 
+<h1 class="title">SKILLS </h1>
+
 <div class="picture">
   <img src="./Images/mover.png" alt="" class="vert-move">
 </div>
-
-
-<h1 class="title">SKILLS </h1>
 
 <div class="bg">
   <br><br>

--- a/index.html
+++ b/index.html
@@ -296,7 +296,7 @@
                 <i class="fab fa-linkedin-in"></i></a>
               <i class="fab fa-twitter"></i>
              <a href="https://github.com/2024-SANDHYA" target="_blank"> <i class="fab fa-github"></i></a>
-              <a href="sandhyaagarwal03180@gmail.com"> <i class="fas fa-paper-plane"></i>  </a>
+              <a href="mailto:sandhyaagarwal03180@gmail.com"> <i class="fas fa-paper-plane"></i>  </a>
 
             </p>
           

--- a/skills.css
+++ b/skills.css
@@ -25,7 +25,6 @@ font-family: 'Varela Round', sans-serif;
 margin-bottom: 0px;
 padding-top:0px;
 margin-top: 0px;
-    padding-left: 40%;
     font-family: 'Otomanopee One', sans-serif;
 font-size: 25px;
 cursor:context-menu;
@@ -105,4 +104,22 @@ img.vert-move {
         background-size: cover;
         width: 100%;
       
+}
+
+@media (max-width: 1060px) {
+.vert-move{
+    float: none;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    margin: 20px auto;
+    padding-top: 20px;
+}
+
+.contain{
+    position: relative;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+}
 }


### PR DESCRIPTION
As mentioned in #2 

1. `div.main` has been disposed of. Relevant CSS properties have been commented out in case required in future.
2. `flip-card` has been put inside `flip-card-container` that has grid layout.
3. `.picture` put below heading.
4. `.vert-move` now centers itself as a separate block when viewport is narrow.
5. `.content` too is centered below `.vert-move` on smaller viewport.
6. `.cont` earlier added margin on top of 100% width, making it overflow. Width has now been reduced to 90% to allow margins.
7. Added `mailto:` before email address.